### PR TITLE
Creación y solic de la ruta prueba desde close #12

### DIFF
--- a/ponce-admin.php
+++ b/ponce-admin.php
@@ -7,20 +7,22 @@
  * Author: Ponceleón Software
  * Author URI: http://www.ponceleon.site
  */
+//Endpoint prueba//
+add_action( 'rest_api_init', function () {
+  register_rest_route( 'ponceadmin/v2', 'prueba', array(
+    'methods' => 'GET',
+    'callback' => 'prueba',
+ ) );
+} );
 
+function prueba(){
+return 'yikes';
+}
+//Endpoint prueba//
 
-/*Pendientes: 
-Hacer enqueue de styles:
-  TailwindCSS (X):
-  	Si se hace un enqueue de styles (los estilos se encadenan al head del wp), se mezclan los estilos encadenados con los propios de wp
-  Frame.css(✓):
-  	Un estilo propio del frame renderizado
-
-Hacer enqueue de ejecución de script:
-    -Renderizador del frame (✓)
-*/
 
 wp_enqueue_style('frame-css','/wp-content/plugins/Ponce-admin/style/frame.css');
-
 wp_enqueue_script( 'main', '/wp-content/plugins/Ponce-admin/scripts/main.js', array(), null, true );    
+
+
 ?>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -31,3 +31,28 @@ window.addEventListener("load", function () {
     });
   });
 });
+
+/*Esta es una llamada al endpoint creado en ponce-admin.php, su ubicación y funcionalidad son temporales. Se planea
+implementar una ruta para cada ajuste próximamente*/
+//Esta ruta es válida sólo para instalaciones locales, en caso de dominios en linea usar: domainName.com/sub-folder/?rest_route=/ponceadmin/v2/prueba
+//colocar subfolder solo en caso de trabajar sobre un multisite
+async function wpRestApi() {
+  let response;
+  try {
+    response = await fetch(`/wordpress/wp-json/ponceadmin/v2/prueba`, {
+      method: "GET",
+      "Access-Control-Allow-Origin": "*",
+      mode: "cors",
+      credentials: "include",
+    });
+    let data = await response.json();
+    return data;
+  } catch (e) {
+    alert(e);
+  }
+}
+
+let result = wpRestApi();
+result.then((r) => {
+  console.log(r);
+});


### PR DESCRIPTION
# Test Feature
Acá está el código demostrativo para la creación de rutas en back (php) y su respectiva llamada desde js  :computer: :eyes: 